### PR TITLE
feat:Add POST /generations/{id}/audio endpoint and update Generation schema

### DIFF
--- a/src/libs/Luma/Generated/JsonConverters.AudioGenerationRequestGenerationType.g.cs
+++ b/src/libs/Luma/Generated/JsonConverters.AudioGenerationRequestGenerationType.g.cs
@@ -1,0 +1,49 @@
+#nullable enable
+
+namespace Luma.JsonConverters
+{
+    /// <inheritdoc />
+    public sealed class AudioGenerationRequestGenerationTypeJsonConverter : global::System.Text.Json.Serialization.JsonConverter<global::Luma.AudioGenerationRequestGenerationType>
+    {
+        /// <inheritdoc />
+        public override global::Luma.AudioGenerationRequestGenerationType Read(
+            ref global::System.Text.Json.Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            switch (reader.TokenType)
+            {
+                case global::System.Text.Json.JsonTokenType.String:
+                {
+                    var stringValue = reader.GetString();
+                    if (stringValue != null)
+                    {
+                        return global::Luma.AudioGenerationRequestGenerationTypeExtensions.ToEnum(stringValue) ?? default;
+                    }
+                    
+                    break;
+                }
+                case global::System.Text.Json.JsonTokenType.Number:
+                {
+                    var numValue = reader.GetInt32();
+                    return (global::Luma.AudioGenerationRequestGenerationType)numValue;
+                }
+                default:
+                    throw new global::System.ArgumentOutOfRangeException(nameof(reader));
+            }
+
+            return default;
+        }
+
+        /// <inheritdoc />
+        public override void Write(
+            global::System.Text.Json.Utf8JsonWriter writer,
+            global::Luma.AudioGenerationRequestGenerationType value,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            writer = writer ?? throw new global::System.ArgumentNullException(nameof(writer));
+
+            writer.WriteStringValue(global::Luma.AudioGenerationRequestGenerationTypeExtensions.ToValueString(value));
+        }
+    }
+}

--- a/src/libs/Luma/Generated/JsonConverters.AudioGenerationRequestGenerationTypeNullable.g.cs
+++ b/src/libs/Luma/Generated/JsonConverters.AudioGenerationRequestGenerationTypeNullable.g.cs
@@ -1,0 +1,56 @@
+#nullable enable
+
+namespace Luma.JsonConverters
+{
+    /// <inheritdoc />
+    public sealed class AudioGenerationRequestGenerationTypeNullableJsonConverter : global::System.Text.Json.Serialization.JsonConverter<global::Luma.AudioGenerationRequestGenerationType?>
+    {
+        /// <inheritdoc />
+        public override global::Luma.AudioGenerationRequestGenerationType? Read(
+            ref global::System.Text.Json.Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            switch (reader.TokenType)
+            {
+                case global::System.Text.Json.JsonTokenType.String:
+                {
+                    var stringValue = reader.GetString();
+                    if (stringValue != null)
+                    {
+                        return global::Luma.AudioGenerationRequestGenerationTypeExtensions.ToEnum(stringValue);
+                    }
+                    
+                    break;
+                }
+                case global::System.Text.Json.JsonTokenType.Number:
+                {
+                    var numValue = reader.GetInt32();
+                    return (global::Luma.AudioGenerationRequestGenerationType)numValue;
+                }
+                default:
+                    throw new global::System.ArgumentOutOfRangeException(nameof(reader));
+            }
+
+            return default;
+        }
+
+        /// <inheritdoc />
+        public override void Write(
+            global::System.Text.Json.Utf8JsonWriter writer,
+            global::Luma.AudioGenerationRequestGenerationType? value,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            writer = writer ?? throw new global::System.ArgumentNullException(nameof(writer));
+
+            if (value == null)
+            {
+                writer.WriteNullValue();
+            }
+            else
+            {
+                writer.WriteStringValue(global::Luma.AudioGenerationRequestGenerationTypeExtensions.ToValueString(value.Value));
+            }
+        }
+    }
+}

--- a/src/libs/Luma/Generated/JsonConverters.Request.g.cs
+++ b/src/libs/Luma/Generated/JsonConverters.Request.g.cs
@@ -42,12 +42,20 @@ namespace Luma.JsonConverters
                                throw new global::System.InvalidOperationException($"Cannot get type info for {nameof(global::Luma.UpscaleVideoGenerationRequest)}");
                 upscaleVideo = global::System.Text.Json.JsonSerializer.Deserialize(ref reader, typeInfo);
             }
+            global::Luma.AudioGenerationRequest? addAudio = default;
+            if (discriminator?.GenerationType == global::Luma.GenerationRequestDiscriminatorGenerationType.AddAudio)
+            {
+                var typeInfo = typeInfoResolver.GetTypeInfo(typeof(global::Luma.AudioGenerationRequest), options) as global::System.Text.Json.Serialization.Metadata.JsonTypeInfo<global::Luma.AudioGenerationRequest> ??
+                               throw new global::System.InvalidOperationException($"Cannot get type info for {nameof(global::Luma.AudioGenerationRequest)}");
+                addAudio = global::System.Text.Json.JsonSerializer.Deserialize(ref reader, typeInfo);
+            }
 
             var result = new global::Luma.Request(
                 discriminator?.GenerationType,
                 video,
                 image,
-                upscaleVideo
+                upscaleVideo,
+                addAudio
                 );
 
             return result;
@@ -79,6 +87,12 @@ namespace Luma.JsonConverters
                 var typeInfo = typeInfoResolver.GetTypeInfo(typeof(global::Luma.UpscaleVideoGenerationRequest), options) as global::System.Text.Json.Serialization.Metadata.JsonTypeInfo<global::Luma.UpscaleVideoGenerationRequest?> ??
                                throw new global::System.InvalidOperationException($"Cannot get type info for {typeof(global::Luma.UpscaleVideoGenerationRequest).Name}");
                 global::System.Text.Json.JsonSerializer.Serialize(writer, value.UpscaleVideo, typeInfo);
+            }
+            else if (value.IsAddAudio)
+            {
+                var typeInfo = typeInfoResolver.GetTypeInfo(typeof(global::Luma.AudioGenerationRequest), options) as global::System.Text.Json.Serialization.Metadata.JsonTypeInfo<global::Luma.AudioGenerationRequest?> ??
+                               throw new global::System.InvalidOperationException($"Cannot get type info for {typeof(global::Luma.AudioGenerationRequest).Name}");
+                global::System.Text.Json.JsonSerializer.Serialize(writer, value.AddAudio, typeInfo);
             }
         }
     }

--- a/src/libs/Luma/Generated/JsonSerializerContext.g.cs
+++ b/src/libs/Luma/Generated/JsonSerializerContext.g.cs
@@ -15,6 +15,8 @@ namespace Luma
         { 
             typeof(global::Luma.JsonConverters.AspectRatioJsonConverter),
             typeof(global::Luma.JsonConverters.AspectRatioNullableJsonConverter),
+            typeof(global::Luma.JsonConverters.AudioGenerationRequestGenerationTypeJsonConverter),
+            typeof(global::Luma.JsonConverters.AudioGenerationRequestGenerationTypeNullableJsonConverter),
             typeof(global::Luma.JsonConverters.GenerationTypeJsonConverter),
             typeof(global::Luma.JsonConverters.GenerationTypeNullableJsonConverter),
             typeof(global::Luma.JsonConverters.VideoModelOutputDurationEnumJsonConverter),

--- a/src/libs/Luma/Generated/JsonSerializerContextTypes.g.cs
+++ b/src/libs/Luma/Generated/JsonSerializerContextTypes.g.cs
@@ -38,174 +38,182 @@ namespace Luma
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.Credits? Type3 { get; set; }
+        public global::Luma.AudioGenerationRequest? Type3 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public float? Type4 { get; set; }
+        public global::Luma.AudioGenerationRequestGenerationType? Type4 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.Error? Type5 { get; set; }
+        public global::Luma.Credits? Type5 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.Generation? Type6 { get; set; }
+        public float? Type6 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.DateTime? Type7 { get; set; }
+        public global::Luma.Error? Type7 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.GenerationType? Type8 { get; set; }
+        public global::Luma.Generation? Type8 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Guid? Type9 { get; set; }
+        public global::System.DateTime? Type9 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.Request? Type10 { get; set; }
+        public global::Luma.GenerationType? Type10 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.GenerationRequest? Type11 { get; set; }
+        public global::System.Guid? Type11 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.VideoModelOutputDuration? Type12 { get; set; }
+        public global::Luma.Request? Type12 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.VideoModelOutputDurationEnum? Type13 { get; set; }
+        public global::Luma.GenerationRequest? Type13 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.GenerationRequestGenerationType? Type14 { get; set; }
+        public global::Luma.VideoModelOutputDuration? Type14 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.Keyframes? Type15 { get; set; }
+        public global::Luma.VideoModelOutputDurationEnum? Type15 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.Keyframe? Type16 { get; set; }
+        public global::Luma.GenerationRequestGenerationType? Type16 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.GenerationReference? Type17 { get; set; }
+        public global::Luma.Keyframes? Type17 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.GenerationReferenceType? Type18 { get; set; }
+        public global::Luma.Keyframe? Type18 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.ImageReference? Type19 { get; set; }
+        public global::Luma.GenerationReference? Type19 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.ImageReferenceType? Type20 { get; set; }
+        public global::Luma.GenerationReferenceType? Type20 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.KeyframeDiscriminator? Type21 { get; set; }
+        public global::Luma.ImageReference? Type21 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.KeyframeDiscriminatorType? Type22 { get; set; }
+        public global::Luma.ImageReferenceType? Type22 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public bool? Type23 { get; set; }
+        public global::Luma.KeyframeDiscriminator? Type23 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.VideoModel? Type24 { get; set; }
+        public global::Luma.KeyframeDiscriminatorType? Type24 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.VideoModelOutputResolution? Type25 { get; set; }
+        public bool? Type25 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.VideoModelOutputResolutionEnum? Type26 { get; set; }
+        public global::Luma.VideoModel? Type26 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.ImageGenerationRequest? Type27 { get; set; }
+        public global::Luma.VideoModelOutputResolution? Type27 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.ImageGenerationRequestCharacterRef? Type28 { get; set; }
+        public global::Luma.VideoModelOutputResolutionEnum? Type28 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.ImageIdentity? Type29 { get; set; }
+        public global::Luma.ImageGenerationRequest? Type29 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<string>? Type30 { get; set; }
+        public global::Luma.ImageGenerationRequestCharacterRef? Type30 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.ImageGenerationRequestGenerationType? Type31 { get; set; }
+        public global::Luma.ImageIdentity? Type31 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Luma.ImageRef>? Type32 { get; set; }
+        public global::System.Collections.Generic.IList<string>? Type32 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.ImageRef? Type33 { get; set; }
+        public global::Luma.ImageGenerationRequestGenerationType? Type33 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public double? Type34 { get; set; }
+        public global::System.Collections.Generic.IList<global::Luma.ImageRef>? Type34 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.ImageModel? Type35 { get; set; }
+        public global::Luma.ImageRef? Type35 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.ModifyImageRef? Type36 { get; set; }
+        public double? Type36 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.UpscaleVideoGenerationRequest? Type37 { get; set; }
+        public global::Luma.ImageModel? Type37 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.UpscaleVideoGenerationRequestGenerationType? Type38 { get; set; }
+        public global::Luma.ModifyImageRef? Type38 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.GenerationRequestDiscriminator? Type39 { get; set; }
+        public global::Luma.UpscaleVideoGenerationRequest? Type39 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.GenerationRequestDiscriminatorGenerationType? Type40 { get; set; }
+        public global::Luma.UpscaleVideoGenerationRequestGenerationType? Type40 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.State? Type41 { get; set; }
+        public global::Luma.GenerationRequestDiscriminator? Type41 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.ListGenerationResponse? Type42 { get; set; }
+        public global::Luma.GenerationRequestDiscriminatorGenerationType? Type42 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public int? Type43 { get; set; }
+        public global::Luma.State? Type43 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Luma.Generation>? Type44 { get; set; }
+        public global::Luma.ListGenerationResponse? Type44 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Luma.PingResponse? Type45 { get; set; }
+        public int? Type45 { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public global::System.Collections.Generic.IList<global::Luma.Generation>? Type46 { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public global::Luma.PingResponse? Type47 { get; set; }
     }
 }

--- a/src/libs/Luma/Generated/Luma.GenerationsClient.AddAudioToGeneration.g.cs
+++ b/src/libs/Luma/Generated/Luma.GenerationsClient.AddAudioToGeneration.g.cs
@@ -1,0 +1,244 @@
+
+#nullable enable
+
+namespace Luma
+{
+    public partial class GenerationsClient
+    {
+        partial void PrepareAddAudioToGenerationArguments(
+            global::System.Net.Http.HttpClient httpClient,
+            ref string id,
+            global::Luma.AudioGenerationRequest request);
+        partial void PrepareAddAudioToGenerationRequest(
+            global::System.Net.Http.HttpClient httpClient,
+            global::System.Net.Http.HttpRequestMessage httpRequestMessage,
+            string id,
+            global::Luma.AudioGenerationRequest request);
+        partial void ProcessAddAudioToGenerationResponse(
+            global::System.Net.Http.HttpClient httpClient,
+            global::System.Net.Http.HttpResponseMessage httpResponseMessage);
+
+        partial void ProcessAddAudioToGenerationResponseContent(
+            global::System.Net.Http.HttpClient httpClient,
+            global::System.Net.Http.HttpResponseMessage httpResponseMessage,
+            ref string content);
+
+        /// <summary>
+        /// Add audio to a generation<br/>
+        /// Add audio to a generation by its ID
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="request"></param>
+        /// <param name="cancellationToken">The token to cancel the operation with</param>
+        /// <exception cref="global::Luma.ApiException"></exception>
+        public async global::System.Threading.Tasks.Task<global::Luma.Generation> AddAudioToGenerationAsync(
+            string id,
+            global::Luma.AudioGenerationRequest request,
+            global::System.Threading.CancellationToken cancellationToken = default)
+        {
+            request = request ?? throw new global::System.ArgumentNullException(nameof(request));
+
+            PrepareArguments(
+                client: HttpClient);
+            PrepareAddAudioToGenerationArguments(
+                httpClient: HttpClient,
+                id: ref id,
+                request: request);
+
+            var __pathBuilder = new PathBuilder(
+                path: $"/generations/{id}/audio",
+                baseUri: HttpClient.BaseAddress); 
+            var __path = __pathBuilder.ToString();
+            using var __httpRequest = new global::System.Net.Http.HttpRequestMessage(
+                method: global::System.Net.Http.HttpMethod.Post,
+                requestUri: new global::System.Uri(__path, global::System.UriKind.RelativeOrAbsolute));
+#if NET6_0_OR_GREATER
+            __httpRequest.Version = global::System.Net.HttpVersion.Version11;
+            __httpRequest.VersionPolicy = global::System.Net.Http.HttpVersionPolicy.RequestVersionOrHigher;
+#endif
+
+            foreach (var __authorization in Authorizations)
+            {
+                if (__authorization.Type == "Http" ||
+                    __authorization.Type == "OAuth2")
+                {
+                    __httpRequest.Headers.Authorization = new global::System.Net.Http.Headers.AuthenticationHeaderValue(
+                        scheme: __authorization.Name,
+                        parameter: __authorization.Value);
+                }
+                else if (__authorization.Type == "ApiKey" &&
+                         __authorization.Location == "Header")
+                {
+                    __httpRequest.Headers.Add(__authorization.Name, __authorization.Value);
+                }
+            }
+            var __httpRequestContentBody = request.ToJson(JsonSerializerContext);
+            var __httpRequestContent = new global::System.Net.Http.StringContent(
+                content: __httpRequestContentBody,
+                encoding: global::System.Text.Encoding.UTF8,
+                mediaType: "application/json");
+            __httpRequest.Content = __httpRequestContent;
+
+            PrepareRequest(
+                client: HttpClient,
+                request: __httpRequest);
+            PrepareAddAudioToGenerationRequest(
+                httpClient: HttpClient,
+                httpRequestMessage: __httpRequest,
+                id: id,
+                request: request);
+
+            using var __response = await HttpClient.SendAsync(
+                request: __httpRequest,
+                completionOption: global::System.Net.Http.HttpCompletionOption.ResponseContentRead,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            ProcessResponse(
+                client: HttpClient,
+                response: __response);
+            ProcessAddAudioToGenerationResponse(
+                httpClient: HttpClient,
+                httpResponseMessage: __response);
+            // Error
+            if (!__response.IsSuccessStatusCode)
+            {
+                string? __content_default = null;
+                global::Luma.Error? __value_default = null;
+                if (ReadResponseAsString)
+                {
+                    __content_default = await __response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                    __value_default = global::Luma.Error.FromJson(__content_default, JsonSerializerContext);
+                }
+                else
+                {
+                    var __contentStream_default = await __response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+                    __value_default = await global::Luma.Error.FromJsonStreamAsync(__contentStream_default, JsonSerializerContext).ConfigureAwait(false);
+                }
+
+                throw new global::Luma.ApiException<global::Luma.Error>(
+                    message: __content_default ?? __response.ReasonPhrase ?? string.Empty,
+                    statusCode: __response.StatusCode)
+                {
+                    ResponseBody = __content_default,
+                    ResponseObject = __value_default,
+                    ResponseHeaders = global::System.Linq.Enumerable.ToDictionary(
+                        __response.Headers,
+                        h => h.Key,
+                        h => h.Value),
+                };
+            }
+
+            if (ReadResponseAsString)
+            {
+                var __content = await __response.Content.ReadAsStringAsync(
+#if NET5_0_OR_GREATER
+                    cancellationToken
+#endif
+                ).ConfigureAwait(false);
+
+                ProcessResponseContent(
+                    client: HttpClient,
+                    response: __response,
+                    content: ref __content);
+                ProcessAddAudioToGenerationResponseContent(
+                    httpClient: HttpClient,
+                    httpResponseMessage: __response,
+                    content: ref __content);
+
+                try
+                {
+                    __response.EnsureSuccessStatusCode();
+                }
+                catch (global::System.Net.Http.HttpRequestException __ex)
+                {
+                    throw new global::Luma.ApiException(
+                        message: __content ?? __response.ReasonPhrase ?? string.Empty,
+                        innerException: __ex,
+                        statusCode: __response.StatusCode)
+                    {
+                        ResponseBody = __content,
+                        ResponseHeaders = global::System.Linq.Enumerable.ToDictionary(
+                            __response.Headers,
+                            h => h.Key,
+                            h => h.Value),
+                    };
+                }
+
+                return
+                    global::Luma.Generation.FromJson(__content, JsonSerializerContext) ??
+                    throw new global::System.InvalidOperationException($"Response deserialization failed for \"{__content}\" ");
+            }
+            else
+            {
+                try
+                {
+                    __response.EnsureSuccessStatusCode();
+                }
+                catch (global::System.Net.Http.HttpRequestException __ex)
+                {
+                    throw new global::Luma.ApiException(
+                        message: __response.ReasonPhrase ?? string.Empty,
+                        innerException: __ex,
+                        statusCode: __response.StatusCode)
+                    {
+                        ResponseHeaders = global::System.Linq.Enumerable.ToDictionary(
+                            __response.Headers,
+                            h => h.Key,
+                            h => h.Value),
+                    };
+                }
+
+                using var __content = await __response.Content.ReadAsStreamAsync(
+#if NET5_0_OR_GREATER
+                    cancellationToken
+#endif
+                ).ConfigureAwait(false);
+
+                return
+                    await global::Luma.Generation.FromJsonStreamAsync(__content, JsonSerializerContext).ConfigureAwait(false) ??
+                    throw new global::System.InvalidOperationException("Response deserialization failed.");
+            }
+        }
+
+        /// <summary>
+        /// Add audio to a generation<br/>
+        /// Add audio to a generation by its ID
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="callbackUrl">
+        /// The callback URL for the audio
+        /// </param>
+        /// <param name="generationType">
+        /// Default Value: add_audio
+        /// </param>
+        /// <param name="negativePrompt">
+        /// The negative prompt of the audio
+        /// </param>
+        /// <param name="prompt">
+        /// The prompt of the audio
+        /// </param>
+        /// <param name="cancellationToken">The token to cancel the operation with</param>
+        /// <exception cref="global::System.InvalidOperationException"></exception>
+        public async global::System.Threading.Tasks.Task<global::Luma.Generation> AddAudioToGenerationAsync(
+            string id,
+            string? callbackUrl = default,
+            global::Luma.AudioGenerationRequestGenerationType? generationType = default,
+            string? negativePrompt = default,
+            string? prompt = default,
+            global::System.Threading.CancellationToken cancellationToken = default)
+        {
+            var __request = new global::Luma.AudioGenerationRequest
+            {
+                CallbackUrl = callbackUrl,
+                GenerationType = generationType,
+                NegativePrompt = negativePrompt,
+                Prompt = prompt,
+            };
+
+            return await AddAudioToGenerationAsync(
+                id: id,
+                request: __request,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/libs/Luma/Generated/Luma.IGenerationsClient.AddAudioToGeneration.g.cs
+++ b/src/libs/Luma/Generated/Luma.IGenerationsClient.AddAudioToGeneration.g.cs
@@ -1,0 +1,47 @@
+#nullable enable
+
+namespace Luma
+{
+    public partial interface IGenerationsClient
+    {
+        /// <summary>
+        /// Add audio to a generation<br/>
+        /// Add audio to a generation by its ID
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="request"></param>
+        /// <param name="cancellationToken">The token to cancel the operation with</param>
+        /// <exception cref="global::Luma.ApiException"></exception>
+        global::System.Threading.Tasks.Task<global::Luma.Generation> AddAudioToGenerationAsync(
+            string id,
+            global::Luma.AudioGenerationRequest request,
+            global::System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add audio to a generation<br/>
+        /// Add audio to a generation by its ID
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="callbackUrl">
+        /// The callback URL for the audio
+        /// </param>
+        /// <param name="generationType">
+        /// Default Value: add_audio
+        /// </param>
+        /// <param name="negativePrompt">
+        /// The negative prompt of the audio
+        /// </param>
+        /// <param name="prompt">
+        /// The prompt of the audio
+        /// </param>
+        /// <param name="cancellationToken">The token to cancel the operation with</param>
+        /// <exception cref="global::System.InvalidOperationException"></exception>
+        global::System.Threading.Tasks.Task<global::Luma.Generation> AddAudioToGenerationAsync(
+            string id,
+            string? callbackUrl = default,
+            global::Luma.AudioGenerationRequestGenerationType? generationType = default,
+            string? negativePrompt = default,
+            string? prompt = default,
+            global::System.Threading.CancellationToken cancellationToken = default);
+    }
+}

--- a/src/libs/Luma/Generated/Luma.Models.AudioGenerationRequest.Json.g.cs
+++ b/src/libs/Luma/Generated/Luma.Models.AudioGenerationRequest.Json.g.cs
@@ -1,0 +1,92 @@
+#nullable enable
+
+namespace Luma
+{
+    public sealed partial class AudioGenerationRequest
+    {
+        /// <summary>
+        /// Serializes the current instance to a JSON string using the provided JsonSerializerContext.
+        /// </summary>
+        public string ToJson(
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return global::System.Text.Json.JsonSerializer.Serialize(
+                this,
+                this.GetType(),
+                jsonSerializerContext);
+        }
+
+        /// <summary>
+        /// Serializes the current instance to a JSON string using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public string ToJson(
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.Serialize(
+                this,
+                jsonSerializerOptions);
+        }
+
+        /// <summary>
+        /// Deserializes a JSON string using the provided JsonSerializerContext.
+        /// </summary>
+        public static global::Luma.AudioGenerationRequest? FromJson(
+            string json,
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return global::System.Text.Json.JsonSerializer.Deserialize(
+                json,
+                typeof(global::Luma.AudioGenerationRequest),
+                jsonSerializerContext) as global::Luma.AudioGenerationRequest;
+        }
+
+        /// <summary>
+        /// Deserializes a JSON string using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public static global::Luma.AudioGenerationRequest? FromJson(
+            string json,
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.Deserialize<global::Luma.AudioGenerationRequest>(
+                json,
+                jsonSerializerOptions);
+        }
+
+        /// <summary>
+        /// Deserializes a JSON stream using the provided JsonSerializerContext.
+        /// </summary>
+        public static async global::System.Threading.Tasks.ValueTask<global::Luma.AudioGenerationRequest?> FromJsonStreamAsync(
+            global::System.IO.Stream jsonStream,
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return (await global::System.Text.Json.JsonSerializer.DeserializeAsync(
+                jsonStream,
+                typeof(global::Luma.AudioGenerationRequest),
+                jsonSerializerContext).ConfigureAwait(false)) as global::Luma.AudioGenerationRequest;
+        }
+
+        /// <summary>
+        /// Deserializes a JSON stream using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public static global::System.Threading.Tasks.ValueTask<global::Luma.AudioGenerationRequest?> FromJsonStreamAsync(
+            global::System.IO.Stream jsonStream,
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.DeserializeAsync<global::Luma.AudioGenerationRequest?>(
+                jsonStream,
+                jsonSerializerOptions);
+        }
+    }
+}

--- a/src/libs/Luma/Generated/Luma.Models.AudioGenerationRequest.g.cs
+++ b/src/libs/Luma/Generated/Luma.Models.AudioGenerationRequest.g.cs
@@ -1,0 +1,79 @@
+
+#nullable enable
+
+namespace Luma
+{
+    /// <summary>
+    /// The audio generation request object
+    /// </summary>
+    public sealed partial class AudioGenerationRequest
+    {
+        /// <summary>
+        /// The callback URL for the audio
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("callback_url")]
+        public string? CallbackUrl { get; set; }
+
+        /// <summary>
+        /// Default Value: add_audio
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("generation_type")]
+        [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Luma.JsonConverters.AudioGenerationRequestGenerationTypeJsonConverter))]
+        public global::Luma.AudioGenerationRequestGenerationType? GenerationType { get; set; }
+
+        /// <summary>
+        /// The negative prompt of the audio
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("negative_prompt")]
+        public string? NegativePrompt { get; set; }
+
+        /// <summary>
+        /// The prompt of the audio
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("prompt")]
+        public string? Prompt { get; set; }
+
+        /// <summary>
+        /// Additional properties that are not explicitly defined in the schema
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonExtensionData]
+        public global::System.Collections.Generic.IDictionary<string, object> AdditionalProperties { get; set; } = new global::System.Collections.Generic.Dictionary<string, object>();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AudioGenerationRequest" /> class.
+        /// </summary>
+        /// <param name="callbackUrl">
+        /// The callback URL for the audio
+        /// </param>
+        /// <param name="generationType">
+        /// Default Value: add_audio
+        /// </param>
+        /// <param name="negativePrompt">
+        /// The negative prompt of the audio
+        /// </param>
+        /// <param name="prompt">
+        /// The prompt of the audio
+        /// </param>
+#if NET7_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
+#endif
+        public AudioGenerationRequest(
+            string? callbackUrl,
+            global::Luma.AudioGenerationRequestGenerationType? generationType,
+            string? negativePrompt,
+            string? prompt)
+        {
+            this.CallbackUrl = callbackUrl;
+            this.GenerationType = generationType;
+            this.NegativePrompt = negativePrompt;
+            this.Prompt = prompt;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AudioGenerationRequest" /> class.
+        /// </summary>
+        public AudioGenerationRequest()
+        {
+        }
+    }
+}

--- a/src/libs/Luma/Generated/Luma.Models.AudioGenerationRequestGenerationType.g.cs
+++ b/src/libs/Luma/Generated/Luma.Models.AudioGenerationRequestGenerationType.g.cs
@@ -1,0 +1,45 @@
+
+#nullable enable
+
+namespace Luma
+{
+    /// <summary>
+    /// Default Value: add_audio
+    /// </summary>
+    public enum AudioGenerationRequestGenerationType
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        AddAudio,
+    }
+
+    /// <summary>
+    /// Enum extensions to do fast conversions without the reflection.
+    /// </summary>
+    public static class AudioGenerationRequestGenerationTypeExtensions
+    {
+        /// <summary>
+        /// Converts an enum to a string.
+        /// </summary>
+        public static string ToValueString(this AudioGenerationRequestGenerationType value)
+        {
+            return value switch
+            {
+                AudioGenerationRequestGenerationType.AddAudio => "add_audio",
+                _ => throw new global::System.ArgumentOutOfRangeException(nameof(value), value, null),
+            };
+        }
+        /// <summary>
+        /// Converts an string to a enum.
+        /// </summary>
+        public static AudioGenerationRequestGenerationType? ToEnum(string value)
+        {
+            return value switch
+            {
+                "add_audio" => AudioGenerationRequestGenerationType.AddAudio,
+                _ => null,
+            };
+        }
+    }
+}

--- a/src/libs/Luma/Generated/Luma.Models.GenerationRequestDiscriminatorGenerationType.g.cs
+++ b/src/libs/Luma/Generated/Luma.Models.GenerationRequestDiscriminatorGenerationType.g.cs
@@ -20,6 +20,10 @@ namespace Luma
         /// 
         /// </summary>
         UpscaleVideo,
+        /// <summary>
+        /// 
+        /// </summary>
+        AddAudio,
     }
 
     /// <summary>
@@ -37,6 +41,7 @@ namespace Luma
                 GenerationRequestDiscriminatorGenerationType.Video => "video",
                 GenerationRequestDiscriminatorGenerationType.Image => "image",
                 GenerationRequestDiscriminatorGenerationType.UpscaleVideo => "upscale_video",
+                GenerationRequestDiscriminatorGenerationType.AddAudio => "add_audio",
                 _ => throw new global::System.ArgumentOutOfRangeException(nameof(value), value, null),
             };
         }
@@ -50,6 +55,7 @@ namespace Luma
                 "video" => GenerationRequestDiscriminatorGenerationType.Video,
                 "image" => GenerationRequestDiscriminatorGenerationType.Image,
                 "upscale_video" => GenerationRequestDiscriminatorGenerationType.UpscaleVideo,
+                "add_audio" => GenerationRequestDiscriminatorGenerationType.AddAudio,
                 _ => null,
             };
         }

--- a/src/libs/Luma/Generated/Luma.Models.Request.g.cs
+++ b/src/libs/Luma/Generated/Luma.Models.Request.g.cs
@@ -120,13 +120,49 @@ namespace Luma
         }
 
         /// <summary>
+        /// The audio generation request object
+        /// </summary>
+#if NET6_0_OR_GREATER
+        public global::Luma.AudioGenerationRequest? AddAudio { get; init; }
+#else
+        public global::Luma.AudioGenerationRequest? AddAudio { get; }
+#endif
+
+        /// <summary>
+        /// 
+        /// </summary>
+#if NET6_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, nameof(AddAudio))]
+#endif
+        public bool IsAddAudio => AddAudio != null;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public static implicit operator Request(global::Luma.AudioGenerationRequest value) => new Request(value);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public static implicit operator global::Luma.AudioGenerationRequest?(Request @this) => @this.AddAudio;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public Request(global::Luma.AudioGenerationRequest? value)
+        {
+            AddAudio = value;
+        }
+
+        /// <summary>
         /// 
         /// </summary>
         public Request(
             global::Luma.GenerationRequestDiscriminatorGenerationType? generationType,
             global::Luma.GenerationRequest? video,
             global::Luma.ImageGenerationRequest? image,
-            global::Luma.UpscaleVideoGenerationRequest? upscaleVideo
+            global::Luma.UpscaleVideoGenerationRequest? upscaleVideo,
+            global::Luma.AudioGenerationRequest? addAudio
             )
         {
             GenerationType = generationType;
@@ -134,12 +170,14 @@ namespace Luma
             Video = video;
             Image = image;
             UpscaleVideo = upscaleVideo;
+            AddAudio = addAudio;
         }
 
         /// <summary>
         /// 
         /// </summary>
         public object? Object =>
+            AddAudio as object ??
             UpscaleVideo as object ??
             Image as object ??
             Video as object 
@@ -150,7 +188,7 @@ namespace Luma
         /// </summary>
         public bool Validate()
         {
-            return IsVideo && !IsImage && !IsUpscaleVideo || !IsVideo && IsImage && !IsUpscaleVideo || !IsVideo && !IsImage && IsUpscaleVideo;
+            return IsVideo && !IsImage && !IsUpscaleVideo && !IsAddAudio || !IsVideo && IsImage && !IsUpscaleVideo && !IsAddAudio || !IsVideo && !IsImage && IsUpscaleVideo && !IsAddAudio || !IsVideo && !IsImage && !IsUpscaleVideo && IsAddAudio;
         }
 
         /// <summary>
@@ -160,6 +198,7 @@ namespace Luma
             global::System.Func<global::Luma.GenerationRequest?, TResult>? video = null,
             global::System.Func<global::Luma.ImageGenerationRequest?, TResult>? image = null,
             global::System.Func<global::Luma.UpscaleVideoGenerationRequest?, TResult>? upscaleVideo = null,
+            global::System.Func<global::Luma.AudioGenerationRequest?, TResult>? addAudio = null,
             bool validate = true)
         {
             if (validate)
@@ -179,6 +218,10 @@ namespace Luma
             {
                 return upscaleVideo(UpscaleVideo!);
             }
+            else if (IsAddAudio && addAudio != null)
+            {
+                return addAudio(AddAudio!);
+            }
 
             return default(TResult);
         }
@@ -190,6 +233,7 @@ namespace Luma
             global::System.Action<global::Luma.GenerationRequest?>? video = null,
             global::System.Action<global::Luma.ImageGenerationRequest?>? image = null,
             global::System.Action<global::Luma.UpscaleVideoGenerationRequest?>? upscaleVideo = null,
+            global::System.Action<global::Luma.AudioGenerationRequest?>? addAudio = null,
             bool validate = true)
         {
             if (validate)
@@ -209,6 +253,10 @@ namespace Luma
             {
                 upscaleVideo?.Invoke(UpscaleVideo!);
             }
+            else if (IsAddAudio)
+            {
+                addAudio?.Invoke(AddAudio!);
+            }
         }
 
         /// <summary>
@@ -224,6 +272,8 @@ namespace Luma
                 typeof(global::Luma.ImageGenerationRequest),
                 UpscaleVideo,
                 typeof(global::Luma.UpscaleVideoGenerationRequest),
+                AddAudio,
+                typeof(global::Luma.AudioGenerationRequest),
             };
             const int offset = unchecked((int)2166136261);
             const int prime = 16777619;
@@ -242,7 +292,8 @@ namespace Luma
             return
                 global::System.Collections.Generic.EqualityComparer<global::Luma.GenerationRequest?>.Default.Equals(Video, other.Video) &&
                 global::System.Collections.Generic.EqualityComparer<global::Luma.ImageGenerationRequest?>.Default.Equals(Image, other.Image) &&
-                global::System.Collections.Generic.EqualityComparer<global::Luma.UpscaleVideoGenerationRequest?>.Default.Equals(UpscaleVideo, other.UpscaleVideo) 
+                global::System.Collections.Generic.EqualityComparer<global::Luma.UpscaleVideoGenerationRequest?>.Default.Equals(UpscaleVideo, other.UpscaleVideo) &&
+                global::System.Collections.Generic.EqualityComparer<global::Luma.AudioGenerationRequest?>.Default.Equals(AddAudio, other.AddAudio) 
                 ;
         }
 

--- a/src/libs/Luma/openapi.yaml
+++ b/src/libs/Luma/openapi.yaml
@@ -203,6 +203,40 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  '/generations/{id}/audio':
+    post:
+      tags:
+        - Generations
+      summary: Add audio to a generation
+      description: Add audio to a generation by its ID
+      operationId: addAudioToGeneration
+      parameters:
+        - name: id
+          in: path
+          description: The ID of the generation
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: The audio generation request object
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AudioGenerationRequest'
+        required: true
+      responses:
+        '200':
+          description: Audio added to generation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Generation'
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   '/generations/{id}/upscale':
     post:
       tags:
@@ -292,6 +326,25 @@ components:
         summary: Video
         value:
           video: https://example.com/video.mp4
+    AudioGenerationRequest:
+      type: object
+      properties:
+        callback_url:
+          type: string
+          description: The callback URL for the audio
+          format: uri
+        generation_type:
+          enum:
+            - add_audio
+          type: string
+          default: add_audio
+        negative_prompt:
+          type: string
+          description: The negative prompt of the audio
+        prompt:
+          type: string
+          description: The prompt of the audio
+      description: The audio generation request object
     Credits:
       required:
         - credit_balance
@@ -337,6 +390,7 @@ components:
             - $ref: '#/components/schemas/GenerationRequest'
             - $ref: '#/components/schemas/ImageGenerationRequest'
             - $ref: '#/components/schemas/UpscaleVideoGenerationRequest'
+            - $ref: '#/components/schemas/AudioGenerationRequest'
           description: The request of the generation
         state:
           $ref: '#/components/schemas/State'


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new API endpoint that enables users to add audio to an existing generation by providing the necessary details.
  - Enhanced the audio generation process by incorporating additional request parameters, ensuring more comprehensive audio submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->